### PR TITLE
Use dict2items as iteritems fails on Python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ uwsgi_config_available_path: "{{ _uwsgi_config_available_path }}"
 uwsgi_config_enabled_path: "{{ _uwsgi_config_enabled_path }}"
 uwsgi_user: 'www-data'
 uwsgi_group: 'root'
+uwsgi_ensure_user_group_exists: True
 uwsgi_config_log_path: "{{ _uwsgi_config_log_path }}"
 uwsgi_config_run_path: "{{ _uwsgi_config_run_path }}"
 uwsgi_apps_defaults: "{{ _uwsgi_apps_defaults }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -69,5 +69,7 @@ uwsgi_systemd:
         Type: 'notify'
         StandardError: 'syslog'
         NotifyAccess: 'all'
+        User: 'root'
+        Group: 'root'
       Install:
         WantedBy: 'multi-user.target'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,6 +2,20 @@
 
 # All tasks about uwsgi configuration
 
+- name: 'CONFIG | Ensure uwsgi group exists'
+  group:
+    name: "{{ uwsgi_group }}"
+    state: present
+  when: uwsgi_ensure_user_group_exists
+
+- name: 'CONFIG | Ensure uwsgi user exists'
+  user:
+    name: "{{ uwsgi_user }}"
+    group: "{{ uwsgi_group }}"
+    shell: /bin/false
+    state: present
+  when: uwsgi_ensure_user_group_exists
+
 - name: 'CONFIG | Ensure log directories exist 4 uswgi'
   file:
     path: "{{ uwsgi_config_log_path }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -22,7 +22,7 @@
     state: 'directory'
     owner: "{{ uwsgi_user }}"
     group: "{{ uwsgi_group }}"
-    mode: '2770'
+    mode: '0775'
   when: 'not uwsgi_install_emperor'
 
 - name: 'CONFIG | Ensure log directories exist 4 uwsgi-emperor'
@@ -31,7 +31,7 @@
     state: 'directory'
     owner: "{{ uwsgi_emperor_user }}"
     group: "{{ uwsgi_emperor_group }}"
-    mode: '2770'
+    mode: '0775'
   when: 'uwsgi_install_emperor'
 
 - name: 'CONFIG | Create app configuration files'

--- a/tasks/manage_variables.yml
+++ b/tasks/manage_variables.yml
@@ -21,6 +21,7 @@
 - name: 'INIT | VARIABLES | Check if OS release vars file exists'
   become: False
   stat:
+    # yamllint disable-line rule:line-length
     path: "{{ role_path }}/vars/os_distribution/{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
   register: 'uwsgi_check_os_release_vars'
   delegate_to: '127.0.0.1'
@@ -37,5 +38,6 @@
 
 
 - name: 'INIT | VARIABLES | Load OS release vars file'
+  # yamllint disable-line rule:line-length
   include_vars: "{{ role_path }}/vars/os_distribution/{{ ansible_distribution | lower }}/{{ ansible_distribution_release | lower }}.yml"
   when: "uwsgi_check_os_release_vars.stat.exists"

--- a/templates/emperor.ini.j2
+++ b/templates/emperor.ini.j2
@@ -3,7 +3,7 @@
 {% for section in item.config.keys() %}
 
 [{{ section }}]
-{% for key, value in item.config[section].iteritems() %}
-{{ key }}={{ value }}
+{% for item in item.config[section] | dict2items %}
+{{ item.key }}={{ item.value }}
 {% endfor %}
 {% endfor %}

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -3,7 +3,7 @@
 {% for section in item.config.keys() %}
 
 [{{ section }}]
-{% for key, value in item.config[section].iteritems() %}
-{{ key }}={{ value }}
+{% for item in item.config[section] | dict2items %}
+{{ item.key }}={{ item.value }}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
I ran into issues with running Ansible on Python 3, this solved it for me. I'm not sure if this also works on Python 2. Please have a look.

More to read on this here: https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html